### PR TITLE
Add a disable switch to the config XML

### DIFF
--- a/src/main/java/ca/islandora/syn/settings/Config.java
+++ b/src/main/java/ca/islandora/syn/settings/Config.java
@@ -6,6 +6,7 @@ import java.util.List;
 public class Config {
     private int version = -1;
     private String header = "";
+    private boolean disabled = false;
     private final List<Site> sites = new ArrayList<>();
     private final List<Token> tokens = new ArrayList<>();
 
@@ -36,5 +37,13 @@ public class Config {
 
     public String getHeader() {
         return this.header;
+    }
+
+    public void setDisabled(final String disabled) {
+        this.disabled = Boolean.parseBoolean(disabled);
+    }
+
+    public boolean getDisabled() {
+        return this.disabled;
     }
 }

--- a/src/main/java/ca/islandora/syn/valve/SynValve.java
+++ b/src/main/java/ca/islandora/syn/valve/SynValve.java
@@ -46,6 +46,7 @@ public class SynValve extends ValveBase {
     private Map<String, Token> staticTokenMap = null;
     private Map<String, Boolean> anonymousGetMap = null;
     private String roleHeader = null;
+    private boolean isDisabled = false;
 
     @Override
     public void invoke(final Request request, final Response response)
@@ -54,7 +55,7 @@ public class SynValve extends ValveBase {
         final SecurityConstraint[] constraints = this.container.getRealm()
                 .findSecurityConstraints(request, request.getContext());
 
-        if ((constraints == null
+        if (this.isDisabled || (constraints == null
                 && !request.getContext().getPreemptiveAuthentication())
             || !hasAuthConstraint(constraints)) {
             this.getNext().invoke(request, response);
@@ -301,6 +302,7 @@ public class SynValve extends ValveBase {
             this.staticTokenMap = SettingsParser.getSiteStaticTokens(sites);
             this.anonymousGetMap = SettingsParser.getSiteAllowAnonymous(sites);
             this.roleHeader = sites.getHeader();
+            this.isDisabled = sites.getDisabled();
         } catch (final Exception e) {
             throw new LifecycleException("Error parsing XML Configuration", e);
         }

--- a/src/test/java/ca/islandora/syn/settings/SettingsParserEnabledTest.java
+++ b/src/test/java/ca/islandora/syn/settings/SettingsParserEnabledTest.java
@@ -1,0 +1,159 @@
+package ca.islandora.syn.settings;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+public class SettingsParserEnabledTest {
+
+    @Test
+    public void testConfigDisabledUpper() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"TRUE\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertTrue(settings.getDisabled());
+    }
+
+    @Test
+    public void testConfigDisabledLower() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"true\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertTrue(settings.getDisabled());
+    }
+
+    @Test
+    public void testConfigDisabledProper() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"True\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertTrue(settings.getDisabled());
+    }
+
+    @Test
+    public void testConfigDisabledCrazy() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"TrUe\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertTrue(settings.getDisabled());
+    }
+
+    @Test
+    public void testConfigEnabledUpper() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"FALSE\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertFalse(settings.getDisabled());
+    }
+
+    @Test
+    public void testConfigEnabledLower() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"false\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertFalse(settings.getDisabled());
+    }
+
+    @Test
+    public void testConfigEnabledProper() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"False\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertFalse(settings.getDisabled());
+    }
+
+
+    @Test
+    public void testConfigEnabledCrazy() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"FaLsE\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertFalse(settings.getDisabled());
+    }
+
+
+    @Test
+    public void testConfigEnabledOther() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"other\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertFalse(settings.getDisabled());
+    }
+
+
+    @Test
+    public void testConfigEnabledBlank() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\" disabled=\"\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertFalse(settings.getDisabled());
+    }
+
+
+    @Test
+    public void testConfigEnabledMissing() throws Exception {
+        final String testXml = String.join("\n"
+                , "<config version=\"1\">"
+                , "  <site url=\"http://test.com\" algorithm=\"RS384\" path=\"test/path.key\" encoding=\"PEM\"/>"
+                , "</config>"
+        );
+
+        final InputStream stream = new ByteArrayInputStream(testXml.getBytes());
+        final Config settings = SettingsParser.getSitesObject(stream);
+        assertFalse(settings.getDisabled());
+    }
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1398

# What does this Pull Request do?

Allows you to add a `disabled="true"` to the `<config>` element in `syn-settings.xml` and it will disable the entire Syn Valve. This will allow you to go back to using Basic Authentication with Fedora, so long as you have configured some users.

# How should this be tested?

1. Stand up a islandora-playbook
1. Pull this PR down and build it (`./gradlew clean build`)
1. Inside the playbook VM, delete the `/opt/tomcat/lib/islandora-syn-1.0.0-all.jar`
1. Copy the `islandora-syn-1.0.0-SNAPSHOT.jar` from the `build/libs` directory in to your vagrant. I do this by putting it in the islandora-playbook directory which syncs to the `/home/ubuntu/islandora` directory inside the VM. So once you have copied the jar to your islandora-playbook directory, from inside your vagrant run `cp /home/ubuntu/islandora/islandora-syn-1.0.0-SNAPSHOT.jar /opt/tomcat/lib/`
1. Restart tomcat8

By default the Valve is enabled so it should work the same.

To disable the Valve and interact with the Fedora interface edit your `/opt/tomcat/conf/tomcat-users.xml` and add a fedoraAdmin user.
```
<?xml version='1.0' encoding='utf-8'?>
<tomcat-users xmlns="http://tomcat.apache.org/xml"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
              version="1.0">
  <user username="islandora" password="islandora" roles="manager-gui"/>
  <user username="fedoraAdmin" password="secret3" roles="fedoraAdmin"/>
</tomcat-users>
```
Then edit the `/opt/tomcat/conf/syn-settings.xml` and change it to.
```
<!-- This file is managed with Ansible -->
<config version='1' header='X-Islandora' disabled="true">
    <site algorithm='RS256' encoding='PEM' anonymous='true' default='true' path='/opt/tomcat/conf/public.key'/>
    <token user='admin' roles='admin,fedoraAdmin'>
      islandora
    </token>
</config>
```
*Note* the `disabled="true"`.

Restart Tomcat.
Try to view `http://localhost:8080/fcrepo/rest`, you should get prompted for a username/password.
Enter the `fedoraAdmin:secret3` pair.
Try to use the Fedora HTML UI to create a new Resource, it should work.

# Interested parties
@Islandora/8-x-committers and @dannylamb and @dwilcox 
