### PR TITLE
Moves maven URL to https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ checkstyle {
 }
 
 repositories {
-     maven { url "http://repo.maven.apache.org/maven2" }
+     maven { url "https://repo.maven.apache.org/maven2" }
 }
 
 dependencies {


### PR DESCRIPTION

**GitHub Issue**: https://github.com/Islandora/documentation/issues/1415

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?
Changes the maven link to using HTTPS

It seems that maven has gotten strict about using HTTPS. With out this fix one cannot access the necessary artifacts from maven to build this project. 

# What's new?
Extremely minimal change - just http->https


# How should this be tested?
* To test simply check out the code as is, try running it to see if it will build.  Then bring in this fix and it should start to build again. 

# Interested parties
@whikloj 
